### PR TITLE
Explicitly set prettytensor version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install -y git wget ttf-freefont
 ENV PYTHONPATH /root/StackGAN
 
 # Install StackGAN dependencies
-RUN pip install prettytensor progressbar python-dateutil \
+RUN pip install prettytensor==0.7.3 progressbar python-dateutil \
     easydict pandas torchfile pillow pyyaml ipdb
 
 # copy local files to image 


### PR DESCRIPTION
Looks like HEAD of prettytensor must be used with HEAD of tensorflow.

Here is the error I'm hitting with version 0.7.4
https://github.com/carpedm20/simulated-unsupervised-tensorflow/issues/5